### PR TITLE
fixed incorrect if case

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -13,7 +13,7 @@ class ApacheClient extends Discord.Client {
     this.eventPath = options.eventPath || "./events";
   }
   login(token) {
-    if (!typeof token == "string") {
+    if (typeof token !== "string") {
       throw new Error("Token must be a string");
     }
     try {


### PR DESCRIPTION
```js
!typeof token == "string"
```
means `(!typeof token) == "string"`. `typeof something` always returns a non-empty string, so `!typeof something` will always be false since ! is negating it (turning it into a boolean)
`false == "string"` can never be true, so this'll always be false
instead what should've been used was
```js
typeof token !== "string"
```
check if the typeof the token isn't string
